### PR TITLE
fix(CRED-93) Ensure that migrations always run

### DIFF
--- a/custom/crediblex/infrastructure/datatables/build.gradle
+++ b/custom/crediblex/infrastructure/datatables/build.gradle
@@ -16,12 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-description = 'Crediblex Fineract Portfolio Starter'
 
-group = 'com.crediblex.fineract.portfolio'
+plugins {
+    id 'java'
+}
+
+description = 'CredibleX Fineract Infrastructure Datatables'
+
+group = 'com.crediblex.fineract'
 
 base {
-    archivesName = 'crediblex-fineract-portfolio-starter'
+    archivesName = 'crediblex-fineract-infrastructure-datatables'
 }
 
 apply from: 'dependencies.gradle'

--- a/custom/crediblex/infrastructure/datatables/dependencies.gradle
+++ b/custom/crediblex/infrastructure/datatables/dependencies.gradle
@@ -16,12 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-description = 'Crediblex Fineract Portfolio Starter'
 
-group = 'com.crediblex.fineract.portfolio'
-
-base {
-    archivesName = 'crediblex-fineract-portfolio-starter'
+dependencies {
 }
-
-apply from: 'dependencies.gradle'

--- a/custom/crediblex/infrastructure/starter/build.gradle
+++ b/custom/crediblex/infrastructure/starter/build.gradle
@@ -23,7 +23,7 @@ plugins {
 
 description = 'CredibleX Fineract Infrastructure Service'
 
-group = 'com.crediblex.fineract'
+group = 'com.crediblex.fineract.infrastructure'
 
 base {
     archivesName = 'crediblex-fineract-infrastructure-service'

--- a/custom/crediblex/infrastructure/starter/src/main/java/com/crediblex/fineract/infrastructure/starter/CrediblexInfrastructureAutoConfiguration.java
+++ b/custom/crediblex/infrastructure/starter/src/main/java/com/crediblex/fineract/infrastructure/starter/CrediblexInfrastructureAutoConfiguration.java
@@ -24,6 +24,5 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScans;
 
 @AutoConfiguration
-@ComponentScans({ @ComponentScan("com.crediblex.fineract.infrastructure.datatables"),
-        @ComponentScan("com.crediblex.fineract.infrastructure.codes") })
+@ComponentScans({ @ComponentScan("com.crediblex.fineract.infrastructure.datatables")})
 public class CrediblexInfrastructureAutoConfiguration {}


### PR DESCRIPTION
Fixes failed migration runs that result from the infrastructure/starter module not getting added to the runtime class path