### PR TITLE
feat(CRED-83): Add component scan for commands infrastructure module

### DIFF
--- a/custom/crediblex/infrastructure/starter/src/main/java/com/crediblex/fineract/infrastructure/starter/CrediblexInfrastructureAutoConfiguration.java
+++ b/custom/crediblex/infrastructure/starter/src/main/java/com/crediblex/fineract/infrastructure/starter/CrediblexInfrastructureAutoConfiguration.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,5 +24,8 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScans;
 
 @AutoConfiguration
-@ComponentScans({ @ComponentScan("com.crediblex.fineract.infrastructure.datatables")})
-public class CrediblexInfrastructureAutoConfiguration {}
+@ComponentScans({@ComponentScan({
+        "com.crediblex.fineract.infrastructure.datatables",
+        "com.crediblex.fineract.commands"})})
+public class CrediblexInfrastructureAutoConfiguration {
+}


### PR DESCRIPTION
add command package scan to infra configuration. did not create a dedicated starter package since commands are standalone and do not have sub-module/domains. as compared to things like savings accounts which belong to the module portfolio or datables which belong to the module infra.