### PR TITLE
fix(CRED-177): Fix Hunging Jib docker Build on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -665,7 +665,7 @@ configure(project.fineractJavaProjects) {
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
 
-        implementation("io.github.kayr:ezy-query-core:0.0.23")
+        implementation("io.github.kayr:ezy-query-core:${project.ezyQueryVersion}")
 
 
         testImplementation( 'org.mockito:mockito-core',

--- a/custom/crediblex/build.gradle
+++ b/custom/crediblex/build.gradle
@@ -18,7 +18,7 @@
  */
 
 plugins{
-    id 'io.github.kayr.gradle.ezyquery' version '0.0.23' apply false
+    id 'io.github.kayr.gradle.ezyquery' version "${ezyQueryVersion}" apply false
 }
 
 subprojects {

--- a/custom/crediblex/infrastructure/commands/build.gradle
+++ b/custom/crediblex/infrastructure/commands/build.gradle
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id 'io.github.kayr.gradle.ezyquery' version '0.0.23' apply false
+    id 'io.github.kayr.gradle.ezyquery' version "${ezyQueryVersion}" apply false
 }
 
 description = 'CredibleX Fineract Commands'

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,4 @@ org.gradle.daemon.idletimeout=10800000
 # Temporarily disabled until we fix configuration cache compatibility
 #org.gradle.configuration-cache=true
 org.gradle.vfs.watch=true
+ezyQueryVersion=0.0.26


### PR DESCRIPTION
## Description
Fix Hunging Jib docker Build on Windows

Building Docker image via Jib needs to be done differently


1. Build tar first
    ./gradlew :custom:docker:jibBuildTar --no-parallel --max-workers=1
    
2. Load the tar as image
    docker load -i custom/docker/build/jib-image.tar