### PR TITLE
fix(LMS-24): Fixes line of credit webhooks to be transaction safe

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/SynchronousCommandProcessingService.java
@@ -167,7 +167,7 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
     }
 
     private void publishHookErrorEvent(CommandWrapper wrapper, JsonCommand command, ErrorInfo errorInfo) {
-        publishHookEvent(wrapper.entityName(), wrapper.actionName(), command, gson.toJson(errorInfo));
+        publishHookEvent(wrapper.entityName(), wrapper.actionName(), command, errorInfo);
     }
 
     private void exceptionWhenTheRequestAlreadyProcessed(CommandWrapper wrapper, String idempotencyKey, boolean retry) {


### PR DESCRIPTION
## Description

This PR fixes an issue where the **ErrorInfo** object was being converted to a **JSON string** before being passed to publishHookEvent. This caused type checks (such as instanceof ErrorInfo) to fail, resulting in incomplete error information being sent to webhooks. With this change, ErrorInfo is now passed directly, ensuring that error details are correctly handled and included in webhook payloads. This improves error reporting and makes debugging easier for webhook consumers.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
