### PR TITLE
fix(LMS-125): update penalty calculation for loan repayments / foreclosure

### DIFF
--- a/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/domain/CustomLoanAccountDomainServiceJpa.java
+++ b/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/domain/CustomLoanAccountDomainServiceJpa.java
@@ -4,6 +4,7 @@ import com.crediblex.fineract.commands.LineOfCreditStatusWebhookPublisher;
 import com.crediblex.fineract.commands.LoanStatusWebhookPublisher;
 import com.crediblex.fineract.infrastructure.commands.utils.LoanTransactionInstallmentUtils;
 import com.crediblex.fineract.portfolio.loanaccount.data.LocStatusAggregationData;
+import com.crediblex.fineract.portfolio.loanaccount.service.CredXLoanChargeWritePlatformService;
 import com.crediblex.fineract.portfolio.loanaccount.util.BackdatedRepaymentValidator;
 import com.crediblex.fineract.portfolio.loanaccount.util.ForeclosureAmountReconciler;
 import com.crediblex.fineract.portfolio.loanaccount.util.ForeclosurePenaltyCalculator;
@@ -12,7 +13,6 @@ import com.crediblex.fineract.portfolio.loanaccount.util.InstallmentPenaltySyncU
 import com.crediblex.fineract.portfolio.loanaccount.util.LoanChargeSettlementUtils;
 import com.crediblex.fineract.portfolio.loanaccount.util.LocForeclosureValidator;
 import com.crediblex.fineract.portfolio.loanaccount.util.LocStatusAggregationUtils;
-import com.crediblex.fineract.portfolio.loanaccount.service.CredXLoanChargeWritePlatformService;
 import com.crediblex.fineract.portfolio.loc.domain.LineOfCredit;
 import com.crediblex.fineract.portfolio.loc.domain.LineOfCreditRepository;
 import java.math.BigDecimal;
@@ -284,16 +284,16 @@ public class CustomLoanAccountDomainServiceJpa extends LoanAccountDomainServiceJ
         // complement of ForeclosurePenaltyCalculator#computePenaltyQuotedForSettlementDate (charges strictly before the
         // date are collected; the rest are waived here). Repayment uses the same waive-on-or-after rule; foreclosure
         // previously skipped it and relied on over-collecting penalty instead.
-        final Map<String, Object> lpiWaiveSummary = credibleXLoanChargeWritePlatformService
-                .waiveOverdueChargesOnOrAfterDate(loan.getId(), foreClosureDate);
+        final Map<String, Object> lpiWaiveSummary = credibleXLoanChargeWritePlatformService.waiveOverdueChargesOnOrAfterDate(loan.getId(),
+                foreClosureDate);
         if (hasWaivedLpiCharges(lpiWaiveSummary)) {
             loan = loanRepositoryWrapper.findOneWithNotFoundDetection(loan.getId(), true);
             if (InstallmentPenaltySyncUtils.syncOutstandingOverduePenaltyOntoSchedule(loan)) {
                 loan = loanAccountService.saveAndFlushLoanWithDataIntegrityViolationChecks(loan);
             }
             org.slf4j.LoggerFactory.getLogger(CustomLoanAccountDomainServiceJpa.class).info(
-                    "Foreclosure on loan {} as of {}: auto-waived {} LPI charge(s) dated on/after the foreclosure date: {}",
-                    loan.getId(), foreClosureDate, lpiWaiveSummary.get("chargesWaived"), lpiWaiveSummary);
+                    "Foreclosure on loan {} as of {}: auto-waived {} LPI charge(s) dated on/after the foreclosure date: {}", loan.getId(),
+                    foreClosureDate, lpiWaiveSummary.get("chargesWaived"), lpiWaiveSummary);
         }
 
         final LoanRepaymentScheduleInstallment foreCloseDetail = loan.fetchLoanForeclosureDetail(foreClosureDate);

--- a/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/domain/CustomLoanAccountDomainServiceJpa.java
+++ b/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/domain/CustomLoanAccountDomainServiceJpa.java
@@ -12,6 +12,7 @@ import com.crediblex.fineract.portfolio.loanaccount.util.InstallmentPenaltySyncU
 import com.crediblex.fineract.portfolio.loanaccount.util.LoanChargeSettlementUtils;
 import com.crediblex.fineract.portfolio.loanaccount.util.LocForeclosureValidator;
 import com.crediblex.fineract.portfolio.loanaccount.util.LocStatusAggregationUtils;
+import com.crediblex.fineract.portfolio.loanaccount.service.CredXLoanChargeWritePlatformService;
 import com.crediblex.fineract.portfolio.loc.domain.LineOfCredit;
 import com.crediblex.fineract.portfolio.loc.domain.LineOfCreditRepository;
 import java.math.BigDecimal;
@@ -112,6 +113,8 @@ public class CustomLoanAccountDomainServiceJpa extends LoanAccountDomainServiceJ
 
     private final AccountAssociationsRepository accountAssociationsRepository;
     private final AccountTransfersWritePlatformService accountTransfersWritePlatformService;
+    private final CredXLoanChargeWritePlatformService credibleXLoanChargeWritePlatformService;
+    private final LoanRepositoryWrapper loanRepositoryWrapper;
     private final ExternalIdFactory externalIdFactory;
 
     // Status/LOC/webhook dependencies
@@ -142,6 +145,7 @@ public class CustomLoanAccountDomainServiceJpa extends LoanAccountDomainServiceJ
             ReprocessLoanTransactionsService reprocessLoanTransactionsService, LoanAccountingBridgeMapper loanAccountingBridgeMapper,
             AccountAssociationsRepository accountAssociationsRepository,
             @Lazy AccountTransfersWritePlatformService accountTransfersWritePlatformService,
+            @Lazy CredXLoanChargeWritePlatformService credibleXLoanChargeWritePlatformService,
             LoanStatusWebhookPublisher loanStatusWebhookPublisher, LineOfCreditStatusWebhookPublisher lineOfCreditStatusWebhookPublisher,
             TransactionTemplate transactionTemplate, LineOfCreditRepository lineOfCreditRepository,
             LocStatusAggregationUtils locStatusAggregationUtils, LoanLineOfCreditParamsRepository loanLineOfCreditParamsRepository) {
@@ -156,6 +160,8 @@ public class CustomLoanAccountDomainServiceJpa extends LoanAccountDomainServiceJ
                 loanAccountingBridgeMapper);
         this.accountAssociationsRepository = accountAssociationsRepository;
         this.accountTransfersWritePlatformService = accountTransfersWritePlatformService;
+        this.credibleXLoanChargeWritePlatformService = credibleXLoanChargeWritePlatformService;
+        this.loanRepositoryWrapper = loanRepositoryWrapper;
         this.externalIdFactory = externalIdFactory;
         this.loanStatusWebhookPublisher = loanStatusWebhookPublisher;
         this.lineOfCreditStatusWebhookPublisher = lineOfCreditStatusWebhookPublisher;
@@ -258,6 +264,38 @@ public class CustomLoanAccountDomainServiceJpa extends LoanAccountDomainServiceJ
         if (InstallmentPenaltySyncUtils.syncOutstandingOverduePenaltyOntoSchedule(loan)) {
             loan = loanAccountService.saveAndFlushLoanWithDataIntegrityViolationChecks(loan);
         }
+
+        // Validations MUST run before updateInstallmentsPostDate: that rewrite replaces the unpaid installment's due
+        // date with the foreclosure date itself. LocForeclosureValidator (and any check that reads the live schedule
+        // due dates) would then always see foreclosureDate == dueDate and incorrectly reject every early LOC
+        // foreclosure as "on or past due".
+        loanDownPaymentTransactionValidator.validateAccountStatus(loan, LoanEvent.LOAN_FORECLOSURE);
+
+        loanForeclosureValidator.validateForForeclosure(loan, foreClosureDate);
+        // Fix 1: for LOC (payable/receivable) loans, block foreclosure once the loan is on/past its earliest unpaid
+        // installment due date - that is no longer an early-settlement scenario. No-op for non-LOC loans.
+        LocForeclosureValidator.validateNotDueOrOverdue(loan, foreClosureDate, loanLineOfCreditParamsRepository.findByLoanId(loan.getId()));
+        // General backdate-too-far-in-the-past guard, independent of (and in addition to) the "not before the
+        // loan's last non-waiver transaction date" check just above - see BackdatedRepaymentValidator javadoc and
+        // BUG_REPORT.md "Backdate limit" finding.
+        BackdatedRepaymentValidator.validateWithinBackdateLimit(loan, foreClosureDate, "foreclosure");
+
+        // Waive LPI dated on/after the foreclosure date BEFORE schedule rewrite and settlement. This is the write-path
+        // complement of ForeclosurePenaltyCalculator#computePenaltyQuotedForSettlementDate (charges strictly before the
+        // date are collected; the rest are waived here). Repayment uses the same waive-on-or-after rule; foreclosure
+        // previously skipped it and relied on over-collecting penalty instead.
+        final Map<String, Object> lpiWaiveSummary = credibleXLoanChargeWritePlatformService
+                .waiveOverdueChargesOnOrAfterDate(loan.getId(), foreClosureDate);
+        if (hasWaivedLpiCharges(lpiWaiveSummary)) {
+            loan = loanRepositoryWrapper.findOneWithNotFoundDetection(loan.getId(), true);
+            if (InstallmentPenaltySyncUtils.syncOutstandingOverduePenaltyOntoSchedule(loan)) {
+                loan = loanAccountService.saveAndFlushLoanWithDataIntegrityViolationChecks(loan);
+            }
+            org.slf4j.LoggerFactory.getLogger(CustomLoanAccountDomainServiceJpa.class).info(
+                    "Foreclosure on loan {} as of {}: auto-waived {} LPI charge(s) dated on/after the foreclosure date: {}",
+                    loan.getId(), foreClosureDate, lpiWaiveSummary.get("chargesWaived"), lpiWaiveSummary);
+        }
+
         final LoanRepaymentScheduleInstallment foreCloseDetail = loan.fetchLoanForeclosureDetail(foreClosureDate);
 
         loanAccrualsProcessingService.processAccrualsOnLoanForeClosure(loan, foreClosureDate, newTransactions);
@@ -273,7 +311,7 @@ public class CustomLoanAccountDomainServiceJpa extends LoanAccountDomainServiceJ
         // ever withdrawing more than the loan actually owes from the linked savings account during foreclosure
         // settlement - see BUG_REPORT.md Finding #3, where this stale cache caused a real 55.12 AED
         // over-withdrawal and left the loan stuck "Overpaid" instead of "Closed".
-        Money penaltyPayable = ForeclosurePenaltyCalculator.computePenaltyPayableFromActiveCharges(loan, foreClosureDate, currency);
+        Money penaltyPayable = ForeclosurePenaltyCalculator.computePenaltyQuotedForSettlementDate(loan, foreClosureDate, currency);
         Money taxPayable = foreCloseDetail.getTaxChargesCharged(currency);
         Money payPrincipal = foreCloseDetail.getPrincipal(currency);
         final Money prepaidFutureInstallmentCredit = calculatePrepaidFutureInstallmentCredit(loan, payPrincipal, currency);
@@ -300,21 +338,6 @@ public class CustomLoanAccountDomainServiceJpa extends LoanAccountDomainServiceJ
 
         LoanTransaction payment = null;
         List<Long> transactionIds = new ArrayList<>();
-
-        // Validations MUST run before updateInstallmentsPostDate: that rewrite replaces the unpaid installment's due
-        // date with the foreclosure date itself. LocForeclosureValidator (and any check that reads the live schedule
-        // due dates) would then always see foreclosureDate == dueDate and incorrectly reject every early LOC
-        // foreclosure as "on or past due".
-        loanDownPaymentTransactionValidator.validateAccountStatus(loan, LoanEvent.LOAN_FORECLOSURE);
-
-        loanForeclosureValidator.validateForForeclosure(loan, foreClosureDate);
-        // Fix 1: for LOC (payable/receivable) loans, block foreclosure once the loan is on/past its earliest unpaid
-        // installment due date - that is no longer an early-settlement scenario. No-op for non-LOC loans.
-        LocForeclosureValidator.validateNotDueOrOverdue(loan, foreClosureDate, loanLineOfCreditParamsRepository.findByLoanId(loan.getId()));
-        // General backdate-too-far-in-the-past guard, independent of (and in addition to) the "not before the
-        // loan's last non-waiver transaction date" check just above - see BackdatedRepaymentValidator javadoc and
-        // BUG_REPORT.md "Backdate limit" finding.
-        BackdatedRepaymentValidator.validateWithinBackdateLimit(loan, foreClosureDate, "foreclosure");
 
         final AccountAssociations accountAssociation = accountAssociationsRepository.findByLoanIdAndType(loan.getId(),
                 AccountAssociationType.LINKED_ACCOUNT_ASSOCIATION.getValue());
@@ -712,11 +735,22 @@ public class CustomLoanAccountDomainServiceJpa extends LoanAccountDomainServiceJ
      */
     private LoanRepaymentScheduleInstallment findStraddlingInstallment(final Loan loan, final LocalDate transactionDate) {
         for (final LoanRepaymentScheduleInstallment installment : loan.getRepaymentScheduleInstallments()) {
+            if (DateUtils.isEqual(transactionDate, installment.getDueDate())) {
+                return installment;
+            }
             if (DateUtils.isDateInRangeFromInclusiveToExclusive(transactionDate, installment.getFromDate(), installment.getDueDate())) {
                 return installment;
             }
         }
         return null;
+    }
+
+    private static boolean hasWaivedLpiCharges(final Map<String, Object> summary) {
+        if (summary == null) {
+            return false;
+        }
+        final Object waived = summary.get("chargesWaived");
+        return waived instanceof Number number && number.intValue() > 0;
     }
 
     @Transactional

--- a/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/service/CredXLoanReadPlatformServiceImpl.java
+++ b/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/service/CredXLoanReadPlatformServiceImpl.java
@@ -285,17 +285,24 @@ public class CredXLoanReadPlatformServiceImpl extends LoanReadPlatformServiceImp
         BigDecimal penaltyDue = result.getPenaltyDue();
         final BigDecimal taxDue = result.getTaxDue();
 
-        // Fix 2: live preview. Settling ON an installment due date is on-time, so LPI posted after midnight
-        // for that EMI (and any later LPI through today) is auto-waived. Quote penalty net of that window
-        // for every product — not only LOC.
-        if (onDate != null && penaltyDue != null && penaltyDue.signum() > 0) {
+        // Fix 2: live preview. The Make Repayment LPI must equal the foreclosure quote for the same value date, and
+        // equal what the write path actually collects. Compute it with the SAME single source of truth the foreclosure
+        // template and settlement use - ForeclosurePenaltyCalculator#computePenaltyPayableFromActiveCharges - which
+        // sums the loan's own active penalty charges dated STRICTLY BEFORE the value date (the collectable set),
+        // waiving the charge accrued on the value date and any later day.
+        //
+        // The previous approaches went through result.getPenaltyDue() (schedule window-allocated penalty, which
+        // buckets current-period LPI onto a not-yet-due installment and could collapse to 0) or through
+        // penaltyAmountDue - lpiWaivedOnSettlement. The latter double-counts: penaltyAmountDue sums charges only up to
+        // the value date, but lpiWaivedOnSettlement waives charges all the way to TODAY, so every extra backdated day
+        // subtracts one more charge that was never in the sum - the accumulating over-waive (e.g. 25 Aug showed 51.28
+        // instead of 64.10). Computing the collectable set directly has no subtraction and cannot drift from
+        // foreclosure. Its complement over [value date, today] is exactly what the settlement auto-waives
+        // (LocDueDateRepaymentUtils#overdueChargeWaiverFromDate), so preview == booked amount.
+        if (onDate != null) {
             final Loan loan = loanRepositoryWrapper.findOneWithNotFoundDetection(loanId, true);
-            final LocalDate waiveFrom = LocDueDateRepaymentUtils.overdueChargeWaiverFromDate(loan, onDate);
-            if (waiveFrom != null && !waiveFrom.isAfter(DateUtils.getBusinessLocalDate())) {
-                final Money waivableLpi = LocDueDateRepaymentUtils.sumWaivableOverdueLpi(loan, waiveFrom, DateUtils.getBusinessLocalDate(),
-                        loan.getCurrency());
-                penaltyDue = penaltyDue.subtract(waivableLpi.getAmount()).max(BigDecimal.ZERO);
-            }
+            penaltyDue = ForeclosurePenaltyCalculator.computePenaltyPayableFromActiveCharges(loan, onDate, loan.getCurrency())
+                    .getAmount();
         }
 
         final BigDecimal totalDue = principalPortion.add(interestDue).add(feeDue).add(penaltyDue).add(taxDue);

--- a/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/service/CredXLoanReadPlatformServiceImpl.java
+++ b/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/service/CredXLoanReadPlatformServiceImpl.java
@@ -301,7 +301,7 @@ public class CredXLoanReadPlatformServiceImpl extends LoanReadPlatformServiceImp
         // (LocDueDateRepaymentUtils#overdueChargeWaiverFromDate), so preview == booked amount.
         if (onDate != null) {
             final Loan loan = loanRepositoryWrapper.findOneWithNotFoundDetection(loanId, true);
-            penaltyDue = ForeclosurePenaltyCalculator.computePenaltyPayableFromActiveCharges(loan, onDate, loan.getCurrency())
+            penaltyDue = ForeclosurePenaltyCalculator.computePenaltyQuotedForSettlementDate(loan, onDate, loan.getCurrency())
                     .getAmount();
         }
 
@@ -2016,8 +2016,8 @@ public class CredXLoanReadPlatformServiceImpl extends LoanReadPlatformServiceImp
         final Collection<LoanSchedulePeriodData> loanSchedulePeriods = this.loanRepaymentsSummaryDAO.fetchLoanRepaymentsSummary(loanId);
         final CurrencyData currency = this.jdbcTemplate.queryForObject(loanCurrencySql, loanCurrencyDataMapper, loanId);
 
-        // Get loan to calculate reversed charges per period
-        Loan loan = loanRepositoryWrapper.findOneWithNotFoundDetection(loanId);
+        // Get loan (with active charges) to calculate reversed charges per period and LPI due
+        Loan loan = loanRepositoryWrapper.findOneWithNotFoundDetection(loanId, true);
         Collection<LoanChargeData> loanCharges = this.customLoanChargeReadPlatformServiceImpl.retrieveLoanCharges(loanId);
 
         List<ExtendedLoanSchedulePeriodData> loanSchedulePeriodsWithStatus = loanSchedulePeriods.stream().map(p -> {
@@ -2033,7 +2033,9 @@ public class CredXLoanReadPlatformServiceImpl extends LoanReadPlatformServiceImp
                 : null;
         CredibleXLoanPenaltyCalculator penaltyCalculator = new CredibleXLoanPenaltyCalculator(loanSchedulePeriodsWithStatus, loanCharges,
                 penaltyWaitPeriodValue, isDrawdownLoan, paymentsAsOf, businessDate);
-        BigDecimal penaltySum = penaltyCalculator.calculatePenaltySum(transactionDate);
+        // Same single source of truth as repayment/foreclosure templates: charges strictly before settlement date.
+        BigDecimal penaltySum = ForeclosurePenaltyCalculator
+                .computePenaltyQuotedForSettlementDate(loan, transactionDate, loan.getCurrency()).getAmount();
         BigDecimal installmentPrincipalAmountDue = penaltyCalculator.calculateTotalOutstandingPrincipal(transactionDate);
         BigDecimal installmentInterestAmountDue = penaltyCalculator.calculateTotalOutstandingInterest(transactionDate);
         BigDecimal remainingPrincipalOutstanding = penaltyCalculator.calculateRemainingPrincipalOutstanding(transactionDate);
@@ -3395,7 +3397,7 @@ public class CredXLoanReadPlatformServiceImpl extends LoanReadPlatformServiceImp
         // (CustomLoanAccountDomainServiceJpa#foreCloseLoan) guarantees this quoted amount always matches what is
         // really withdrawn from the linked savings account - previously they could silently diverge, over-quoting
         // (and over-withdrawing) by exactly the staleness amount.
-        Money penaltyChargesOutstanding = ForeclosurePenaltyCalculator.computePenaltyPayableFromActiveCharges(loan, transactionDate,
+        Money penaltyChargesOutstanding = ForeclosurePenaltyCalculator.computePenaltyQuotedForSettlementDate(loan, transactionDate,
                 currency);
 
         // Quote (settlement card) must equal what foreCloseLoan will actually collect. The raw sum below can exceed the

--- a/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/service/CredXLoanReadPlatformServiceImpl.java
+++ b/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/service/CredXLoanReadPlatformServiceImpl.java
@@ -301,8 +301,7 @@ public class CredXLoanReadPlatformServiceImpl extends LoanReadPlatformServiceImp
         // (LocDueDateRepaymentUtils#overdueChargeWaiverFromDate), so preview == booked amount.
         if (onDate != null) {
             final Loan loan = loanRepositoryWrapper.findOneWithNotFoundDetection(loanId, true);
-            penaltyDue = ForeclosurePenaltyCalculator.computePenaltyQuotedForSettlementDate(loan, onDate, loan.getCurrency())
-                    .getAmount();
+            penaltyDue = ForeclosurePenaltyCalculator.computePenaltyQuotedForSettlementDate(loan, onDate, loan.getCurrency()).getAmount();
         }
 
         final BigDecimal totalDue = principalPortion.add(interestDue).add(feeDue).add(penaltyDue).add(taxDue);

--- a/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculator.java
+++ b/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculator.java
@@ -62,6 +62,17 @@ public final class ForeclosurePenaltyCalculator {
             if (!loanCharge.isPenaltyCharge()) {
                 continue;
             }
+            // A daily LPI charge dated ON or AFTER the settlement date is not payable - it is waived when the loan
+            // settles (a client settling on day D is not charged that day's, or any later day's, late fee). This is
+            // evaluated on the charge's OWN accrual date (due-for-collection date) so it holds whether or not the
+            // charge is still linked to its overdue installment: for a linked charge the installment-due-date filter
+            // below alone would keep every day's LPI (the whole arrears period resolves to one past due date), which
+            // made the quoted LPI a flat sum insensitive to the settlement date. The actual settlement waives exactly
+            // this same set via LocDueDateRepaymentUtils#overdueChargeWaiverFromDate, so quote == booked amount.
+            final LocalDate chargeAccrualDate = loanCharge.getDueDate();
+            if (chargeAccrualDate != null && !DateUtils.isBefore(chargeAccrualDate, foreClosureDate)) {
+                continue;
+            }
             final LocalDate effectiveDueDate = resolveEffectiveDueDateForForeclosure(loanCharge);
             if (effectiveDueDate != null && DateUtils.isAfter(effectiveDueDate, foreClosureDate)) {
                 continue;

--- a/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculator.java
+++ b/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculator.java
@@ -26,60 +26,50 @@ import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanCharge;
 
 /**
- * Single source of truth for "how much penalty is actually payable to foreclose this loan as of this date", shared by
- * both the foreclosure TEMPLATE (the amount quoted to the user before they submit,
- * {@code CredXLoanReadPlatformServiceImpl#retrieveLoanForeclosureTemplate}) and the actual foreclosure SETTLEMENT (the
- * amount really withdrawn from the linked savings account and applied to the loan,
- * {@code CustomLoanAccountDomainServiceJpa#foreCloseLoan}).
+ * Computes how much LPI/penalty is payable when settling a loan on a given value date.
  * <p>
- * {@code Loan#fetchLoanForeclosureDetail()} computes the penalty payable by summing each installment's CACHED
- * {@code penaltyChargesOutstanding} schedule field. On a multi-installment loan with 2+ separately-overdue installments
- * (each carrying its own daily-accruing LPI charges), that cache can go stale/inflated relative to what the loan's
- * actual active charges total - the same class of stale-installment-penalty-cache bug fixed for reverse-LPI in
- * {@code CredXLoanChargeWritePlatformServiceImpl} (see BUG_REPORT.md Finding #2). Left unfixed here, that stale figure
- * drove a REAL over-withdrawal from the linked savings account during foreclosure settlement, leaving the loan stuck
- * "Overpaid" instead of "Closed" (see BUG_REPORT.md Finding #3). Summing directly from {@code loan.getActiveCharges()}
- * (the source of truth) instead avoids that, and using the exact same computation for the template AND the settlement
- * guarantees the amount quoted to the user always matches what is actually withdrawn.
+ * The quoted/collectable amount is the sum of active penalty charges dated <em>strictly before</em> the settlement
+ * date. Charges dated on the settlement date or later are auto-waived by the write path
+ * ({@code CredXLoanChargeWritePlatformService#waiveOverdueChargesOnOrAfterDate} for repayments and foreclosure). Quote
+ * and waiver are deliberate complements, so preview == booked amount.
+ * <p>
+ * Summing from {@code loan.getActiveCharges()} (not the schedule's cached {@code penaltyChargesOutstanding}) avoids
+ * stale-installment-penalty-cache inflation on multi-overdue loans (see BUG_REPORT.md Finding #2/#3).
  */
 public final class ForeclosurePenaltyCalculator {
 
     private ForeclosurePenaltyCalculator() {}
 
     /**
-     * Sums {@code getAmountOutstanding()} across the loan's own ACTIVE penalty charges that are due on/before
-     * {@code foreClosureDate}. For an overdue-installment LPI charge, "due on/before the foreclosure date" is evaluated
-     * against its OWNING installment's due date (via the authoritative {@code LoanOverdueInstallmentCharge} link, same
-     * approach as the Finding #2 fix), not the charge's own due date - which for these charges is deliberately dated
-     * AFTER the installment's due date, during its arrears period. This mirrors, and is deliberately consistent with,
-     * {@code Loan#retrieveIncomeOutstandingTillDate}'s own semantics of "which installments are due-through this date",
-     * so a backdated foreclosure still excludes LPI that only accrued strictly after the foreclosure date.
+     * Penalty quoted to the operator and collected at settlement: active charges dated strictly before
+     * {@code settlementDate}. Used by foreclosure/repayment templates and {@code foreCloseLoan}.
      */
-    public static Money computePenaltyPayableFromActiveCharges(final Loan loan, final LocalDate foreClosureDate,
+    public static Money computePenaltyQuotedForSettlementDate(final Loan loan, final LocalDate settlementDate,
             final MonetaryCurrency currency) {
         Money totalPenaltyPayable = Money.zero(currency);
         for (final LoanCharge loanCharge : loan.getActiveCharges()) {
             if (!loanCharge.isPenaltyCharge()) {
                 continue;
             }
-            // A daily LPI charge dated ON or AFTER the settlement date is not payable - it is waived when the loan
-            // settles (a client settling on day D is not charged that day's, or any later day's, late fee). This is
-            // evaluated on the charge's OWN accrual date (due-for-collection date) so it holds whether or not the
-            // charge is still linked to its overdue installment: for a linked charge the installment-due-date filter
-            // below alone would keep every day's LPI (the whole arrears period resolves to one past due date), which
-            // made the quoted LPI a flat sum insensitive to the settlement date. The actual settlement waives exactly
-            // this same set via LocDueDateRepaymentUtils#overdueChargeWaiverFromDate, so quote == booked amount.
             final LocalDate chargeAccrualDate = loanCharge.getDueDate();
-            if (chargeAccrualDate != null && !DateUtils.isBefore(chargeAccrualDate, foreClosureDate)) {
+            if (chargeAccrualDate != null && !DateUtils.isBefore(chargeAccrualDate, settlementDate)) {
                 continue;
             }
             final LocalDate effectiveDueDate = resolveEffectiveDueDateForForeclosure(loanCharge);
-            if (effectiveDueDate != null && DateUtils.isAfter(effectiveDueDate, foreClosureDate)) {
+            if (effectiveDueDate != null && DateUtils.isAfter(effectiveDueDate, settlementDate)) {
                 continue;
             }
             totalPenaltyPayable = totalPenaltyPayable.plus(loanCharge.getAmountOutstanding(currency));
         }
         return totalPenaltyPayable;
+    }
+
+    /**
+     * Alias for {@link #computePenaltyQuotedForSettlementDate}; kept for existing callers.
+     */
+    public static Money computePenaltyPayableFromActiveCharges(final Loan loan, final LocalDate foreClosureDate,
+            final MonetaryCurrency currency) {
+        return computePenaltyQuotedForSettlementDate(loan, foreClosureDate, currency);
     }
 
     private static LocalDate resolveEffectiveDueDateForForeclosure(final LoanCharge loanCharge) {

--- a/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosureTransactionBreakdown.java
+++ b/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosureTransactionBreakdown.java
@@ -41,7 +41,7 @@ public final class ForeclosureTransactionBreakdown {
         Money principal = foreclosureDetail.getPrincipal(currency);
         Money interest = foreclosureDetail.getInterestCharged(currency);
         Money fees = foreclosureDetail.getFeeChargesCharged(currency);
-        Money penalties = ForeclosurePenaltyCalculator.computePenaltyPayableFromActiveCharges(loan, foreclosureDate, currency);
+        Money penalties = ForeclosurePenaltyCalculator.computePenaltyQuotedForSettlementDate(loan, foreclosureDate, currency);
         Money taxes = foreclosureDetail.getTaxChargesCharged(currency);
 
         if (loan.isFactorRateEnabled()) {

--- a/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/util/LocDueDateRepaymentUtils.java
+++ b/custom/crediblex/portfolio/loanaccount/src/main/java/com/crediblex/fineract/portfolio/loanaccount/util/LocDueDateRepaymentUtils.java
@@ -62,16 +62,15 @@ public final class LocDueDateRepaymentUtils {
     /**
      * First date whose overdue LPI charges should be waived when settling on {@code settlementDate}.
      * <p>
-     * Paying on an installment due date is on-time. LPI for that EMI is not charged until after midnight, so the charge
-     * is dated the next calendar day; the waiver window still starts on the due date so that overnight LPI is waived
-     * when the operator backdates to the due date (e.g. due 14 Aug, LPI posted 15 Aug, value date 14 Aug). Paying on
-     * any other date keeps that day's LPI (window starts the next calendar day).
+     * Settling on a given value date is on-time for that date: the client is not charged the late fee accrued ON the
+     * settlement date (nor any later day's), so the waiver window starts on the settlement date itself. This holds for
+     * an installment due date (overnight LPI dated on/after the due date is waived when the operator backdates to it)
+     * and for any other value date (that day's LPI is waived rather than collected). The foreclosure quote excludes the
+     * same set via {@code ForeclosurePenaltyCalculator#computePenaltyPayableFromActiveCharges}, so the quoted penalty
+     * equals what is actually collected after this auto-waive.
      */
     public static LocalDate overdueChargeWaiverFromDate(final Loan loan, final LocalDate settlementDate) {
-        if (settlementDate == null) {
-            return null;
-        }
-        return isOnInstallmentDueDate(loan, settlementDate) ? settlementDate : settlementDate.plusDays(1);
+        return settlementDate;
     }
 
     /**

--- a/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/domain/CustomLoanAccountDomainServiceForeclosureTest.java
+++ b/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/domain/CustomLoanAccountDomainServiceForeclosureTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.crediblex.fineract.portfolio.loanaccount.service.CredXLoanChargeWritePlatformService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -38,7 +39,6 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionType;
 import org.apache.fineract.portfolio.loanaccount.serialization.LoanDownPaymentTransactionValidator;
 import org.apache.fineract.portfolio.loanaccount.serialization.LoanForeclosureValidator;
-import com.crediblex.fineract.portfolio.loanaccount.service.CredXLoanChargeWritePlatformService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanAccrualsProcessingService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanChargeService;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccount;

--- a/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/domain/CustomLoanAccountDomainServiceForeclosureTest.java
+++ b/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/domain/CustomLoanAccountDomainServiceForeclosureTest.java
@@ -38,6 +38,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanTransaction;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionType;
 import org.apache.fineract.portfolio.loanaccount.serialization.LoanDownPaymentTransactionValidator;
 import org.apache.fineract.portfolio.loanaccount.serialization.LoanForeclosureValidator;
+import com.crediblex.fineract.portfolio.loanaccount.service.CredXLoanChargeWritePlatformService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanAccrualsProcessingService;
 import org.apache.fineract.portfolio.loanaccount.service.LoanChargeService;
 import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
@@ -111,6 +112,9 @@ class CustomLoanAccountDomainServiceForeclosureTest {
 
     @Mock
     private AccountTransfersWritePlatformService accountTransfersWritePlatformService;
+
+    @Mock
+    private CredXLoanChargeWritePlatformService credibleXLoanChargeWritePlatformService;
 
     @Mock
     private ExternalIdFactory externalIdFactory;
@@ -369,6 +373,22 @@ class CustomLoanAccountDomainServiceForeclosureTest {
         assertThat(merged.getInterestOutstanding(currency).getAmount()).isEqualByComparingTo("0.00");
         assertThat(merged.getPrincipalCompleted(currency).getAmount()).isEqualByComparingTo("38435.41");
         assertThat(merged.getPrincipalOutstanding(currency).getAmount()).isEqualByComparingTo("41564.59");
+    }
+
+    @Test
+    @DisplayName("Foreclosure on an installment due date treats that installment as straddling")
+    void findStraddlingInstallmentIncludesExactDueDate() {
+        final LocalDate fromDate = LocalDate.of(2026, 8, 20);
+        final LocalDate dueDate = LocalDate.of(2026, 8, 25);
+        final LoanRepaymentScheduleInstallment installment = new LoanRepaymentScheduleInstallment(loan, 2, fromDate, dueDate,
+                new BigDecimal("1000.00"), new BigDecimal("50.00"), BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, false, null,
+                BigDecimal.ZERO);
+        when(loan.getRepaymentScheduleInstallments()).thenReturn(new ArrayList<>(List.of(installment)));
+
+        final LoanRepaymentScheduleInstallment found = ReflectionTestUtils.invokeMethod(customLoanAccountDomainServiceJpa,
+                "findStraddlingInstallment", loan, dueDate);
+
+        assertThat(found).isSameAs(installment);
     }
 
     @Test

--- a/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/service/CredXLoanReadPlatformServiceImplTest.java
+++ b/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/service/CredXLoanReadPlatformServiceImplTest.java
@@ -33,7 +33,11 @@ import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
 import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
 import org.apache.fineract.portfolio.loanaccount.data.LoanTransactionData;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanCharge;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanOverdueInstallmentCharge;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanTransactionType;
 import org.apache.fineract.portfolio.loanaccount.loanschedule.data.LoanSchedulePeriodData;
 import org.apache.fineract.portfolio.loanproduct.service.LoanEnumerations;
@@ -67,6 +71,9 @@ public class CredXLoanReadPlatformServiceImplTest {
 
     @Mock
     private org.apache.fineract.infrastructure.core.service.database.DatabaseSpecificSQLGenerator sqlGenerator;
+
+    @Mock
+    private LoanRepositoryWrapper loanRepositoryWrapper;
 
     @InjectMocks
     private CredXLoanReadPlatformServiceImpl credXLoanReadPlatformService;
@@ -103,6 +110,8 @@ public class CredXLoanReadPlatformServiceImplTest {
         mockResult.setField("interestDue", BigDecimal.valueOf(10.00));
         mockResult.setField("feeDue", BigDecimal.valueOf(5.00));
         mockResult.setField("penaltyDue", BigDecimal.valueOf(2.00));
+        // The repayment-status SQL coalesces every derived money column to 0; mirror that so totalDue never NPEs.
+        mockResult.setField("taxDue", BigDecimal.ZERO);
         mockResult.setField("netDisbursalAmount", BigDecimal.valueOf(500.00));
 
     }
@@ -151,6 +160,77 @@ public class CredXLoanReadPlatformServiceImplTest {
         assertEquals(BigDecimal.valueOf(500.00), result.getNetDisbursalAmount());
         Assertions.assertFalse(result.isManuallyReversed());
         assertEquals(ExternalId.empty(), result.getExternalId());
+    }
+
+    /**
+     * Make Repayment preview WITH a value date must equal the foreclosure quote and must NOT over-waive as it is
+     * backdated. Reproduces UAT loan 16184 (charges 12.82 dated 20..26 Aug, all linked to installment #1 due 20 Aug):
+     * settling on day D collects the LPI dated STRICTLY BEFORE D. The prior "penaltyAmountDue - lpiWaivedOnSettlement"
+     * subtraction double-counted the charges dated in (D, today], so 25 Aug showed 51.28 instead of 64.10 and each
+     * earlier day dropped one more charge - the accumulating over-waive. Sourcing the penalty straight from
+     * ForeclosurePenaltyCalculator (the same calc the foreclosure quote/settlement use) has no subtraction and stays in
+     * lock-step by construction.
+     */
+    @Test
+    public void repaymentTemplateWithDateMatchesForeclosureAndDoesNotOverWaive() {
+        when(credXLoanTransactionRepository.retrieveLoanRepaymentTemplate(loanId)).thenReturn(mockResult);
+        when(paymentTypeReadPlatformService.retrieveAllPaymentTypes()).thenReturn(new ArrayList<>());
+
+        final MonetaryCurrency currency = new MonetaryCurrency("AED", 2, 0);
+        final Loan loan = loan16184(currency);
+        when(loanRepositoryWrapper.findOneWithNotFoundDetection(loanId, true)).thenReturn(loan);
+
+        // Same figures the foreclosure screen shows for the same dates - no accumulating over-waive.
+        assertEquals(0, new BigDecimal("89.74").compareTo(penaltyPortionOn(LocalDate.of(2026, 8, 27)))); // 20..26
+        assertEquals(0, new BigDecimal("76.92").compareTo(penaltyPortionOn(LocalDate.of(2026, 8, 26)))); // 20..25 (waive 26)
+        assertEquals(0, new BigDecimal("64.10").compareTo(penaltyPortionOn(LocalDate.of(2026, 8, 25)))); // 20..24 (waive 25,26)
+        assertEquals(0, new BigDecimal("51.28").compareTo(penaltyPortionOn(LocalDate.of(2026, 8, 24)))); // 20..23 (waive 24..26)
+    }
+
+    private BigDecimal penaltyPortionOn(final LocalDate onDate) {
+        return credXLoanReadPlatformService.retrieveLoanTransactionTemplate(loanId, onDate).getPenaltyChargesPortion();
+    }
+
+    /** Loan 16184: daily 12.82 penalty charges dated 20..26 Aug, all linked to installment #1 due 20 Aug. */
+    private Loan loan16184(final MonetaryCurrency currency) {
+        final Loan loan = Mockito.mock(Loan.class);
+        Mockito.lenient().when(loan.getCurrency()).thenReturn(currency);
+        final java.util.LinkedHashSet<LoanCharge> charges = new java.util.LinkedHashSet<>();
+        for (LocalDate d = LocalDate.of(2026, 8, 20); !d.isAfter(LocalDate.of(2026, 8, 26)); d = d.plusDays(1)) {
+            charges.add(linkedLpiCharge(d, LocalDate.of(2026, 8, 20), currency));
+        }
+        when(loan.getActiveCharges()).thenReturn(charges);
+        return loan;
+    }
+
+    private LoanCharge linkedLpiCharge(final LocalDate accrualDate, final LocalDate owningDueDate, final MonetaryCurrency currency) {
+        final Money outstanding = Money.of(currency, new BigDecimal("12.82"));
+        final LoanCharge charge = Mockito.mock(LoanCharge.class);
+        when(charge.isPenaltyCharge()).thenReturn(true);
+        when(charge.getDueDate()).thenReturn(accrualDate);
+        Mockito.lenient().when(charge.getAmountOutstanding(currency)).thenReturn(outstanding);
+        Mockito.lenient().when(charge.isOverdueInstallmentCharge()).thenReturn(true);
+        final LoanOverdueInstallmentCharge link = Mockito.mock(LoanOverdueInstallmentCharge.class);
+        final LoanRepaymentScheduleInstallment owning = Mockito.mock(LoanRepaymentScheduleInstallment.class);
+        Mockito.lenient().when(owning.getDueDate()).thenReturn(owningDueDate);
+        Mockito.lenient().when(link.getInstallment()).thenReturn(owning);
+        Mockito.lenient().when(charge.getOverdueInstallmentCharge()).thenReturn(link);
+        return charge;
+    }
+
+    /**
+     * The no-date overload (down payment / non-backdated preview) is unchanged: it keeps the schedule-derived penalty
+     * and never loads the loan for the accrual-date calculation.
+     */
+    @Test
+    public void repaymentTemplateWithoutDateKeepsScheduleDerivedPenalty() {
+        when(credXLoanTransactionRepository.retrieveLoanRepaymentTemplate(loanId)).thenReturn(mockResult);
+        when(paymentTypeReadPlatformService.retrieveAllPaymentTypes()).thenReturn(new ArrayList<>());
+
+        final LoanTransactionData result = credXLoanReadPlatformService.retrieveLoanTransactionTemplate(loanId);
+
+        assertEquals(0, BigDecimal.valueOf(2.00).compareTo(result.getPenaltyChargesPortion()));
+        Mockito.verifyNoInteractions(loanRepositoryWrapper);
     }
 
     @Test

--- a/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculatorTest.java
+++ b/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculatorTest.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.crediblex.fineract.portfolio.loanaccount.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
+import org.apache.fineract.organisation.monetary.data.CurrencyData;
+import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
+import org.apache.fineract.organisation.monetary.domain.Money;
+import org.apache.fineract.organisation.monetary.domain.MoneyHelper;
+import org.apache.fineract.portfolio.loanaccount.domain.Loan;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanCharge;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanOverdueInstallmentCharge;
+import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Reproduces UAT RBF loan 000016184: seven daily "Daily Late Repayment Fee" penalty charges of 12.82 dated 20..26 Aug,
+ * all LINKED to installment #1 (due 20 Aug). A client settling on day D must not be charged the late fee accrued on day
+ * D (or later), so the foreclosure penalty is the sum of charges dated strictly before the settlement date.
+ */
+class ForeclosurePenaltyCalculatorTest {
+
+    private final MonetaryCurrency currency = mock(MonetaryCurrency.class);
+    private final ConfigurationDomainService configurationDomainService = mock(ConfigurationDomainService.class);
+
+    @BeforeEach
+    void setUp() {
+        when(currency.getCode()).thenReturn("AED");
+        when(currency.getDigitsAfterDecimal()).thenReturn(2);
+        when(currency.getCurrencyInMultiplesOf()).thenReturn(0);
+        when(currency.toData()).thenReturn(new CurrencyData("AED", "UAE Dirham", 2, 0, "AED", "currency.AED"));
+        final MoneyHelper moneyHelper = new MoneyHelper();
+        ReflectionTestUtils.setField(moneyHelper, "configurationDomainService", configurationDomainService);
+        lenient().when(configurationDomainService.getRoundingMode()).thenReturn(BigDecimal.ROUND_HALF_UP);
+        moneyHelper.initialize();
+    }
+
+    private Money money(final String amount) {
+        return Money.of(currency, new BigDecimal(amount));
+    }
+
+    /** A daily overdue-installment (LPI) charge accrued on {@code accrualDate}, linked to an installment due on {@code owningDueDate}. */
+    private LoanCharge linkedLpiCharge(final String accrualDate, final String owningDueDate, final String outstanding) {
+        final Money outstandingMoney = money(outstanding);
+        final LocalDate accrual = LocalDate.parse(accrualDate);
+        final LocalDate owningDue = LocalDate.parse(owningDueDate);
+        final LoanCharge charge = mock(LoanCharge.class);
+        when(charge.isPenaltyCharge()).thenReturn(true);
+        when(charge.getDueDate()).thenReturn(accrual);
+        when(charge.getAmountOutstanding(currency)).thenReturn(outstandingMoney);
+        lenient().when(charge.isOverdueInstallmentCharge()).thenReturn(true);
+        final LoanOverdueInstallmentCharge link = mock(LoanOverdueInstallmentCharge.class);
+        final LoanRepaymentScheduleInstallment installment = mock(LoanRepaymentScheduleInstallment.class);
+        lenient().when(installment.getDueDate()).thenReturn(owningDue);
+        lenient().when(link.getInstallment()).thenReturn(installment);
+        lenient().when(charge.getOverdueInstallmentCharge()).thenReturn(link);
+        return charge;
+    }
+
+    /** Loan 16184: daily 12.82 charges dated 20..26 Aug, all linked to installment #1 due 20 Aug. */
+    private Loan loan16184() {
+        final Loan loan = mock(Loan.class);
+        final LinkedHashSet<LoanCharge> charges = new LinkedHashSet<>();
+        for (LocalDate d = LocalDate.parse("2026-08-20"); !d.isAfter(LocalDate.parse("2026-08-26")); d = d.plusDays(1)) {
+            charges.add(linkedLpiCharge(d.toString(), "2026-08-20", "12.82"));
+        }
+        when(loan.getActiveCharges()).thenReturn(charges);
+        return loan;
+    }
+
+    private BigDecimal penaltyAsOf(final Loan loan, final String settlementDate) {
+        return ForeclosurePenaltyCalculator.computePenaltyPayableFromActiveCharges(loan, LocalDate.parse(settlementDate), currency)
+                .getAmount();
+    }
+
+    @Test
+    @DisplayName("Settling today collects all LPI accrued through yesterday (no charge dated today)")
+    void settlingTodayCollectsAllAccrued() {
+        assertThat(penaltyAsOf(loan16184(), "2026-08-27")).isEqualByComparingTo("89.74"); // 7 x 12.82
+    }
+
+    @Test
+    @DisplayName("Settling on 26 Aug waives the 26 Aug LPI even though the charge is linked to the 20 Aug installment")
+    void settlingOn26AugWaivesThatDaysLpi() {
+        assertThat(penaltyAsOf(loan16184(), "2026-08-26")).isEqualByComparingTo("76.92"); // 6 x 12.82 (20..25)
+    }
+
+    @Test
+    @DisplayName("Settling on 25 Aug waives both the 25 and 26 Aug LPI")
+    void settlingOn25AugWaivesTwoDaysLpi() {
+        assertThat(penaltyAsOf(loan16184(), "2026-08-25")).isEqualByComparingTo("64.10"); // 5 x 12.82 (20..24)
+    }
+
+    @Test
+    @DisplayName("Quote is monotonic - one earlier settlement day drops exactly one day's LPI")
+    void quoteIsMonotonicByDay() {
+        final Loan loan = loan16184();
+        assertThat(penaltyAsOf(loan, "2026-08-27")).isEqualByComparingTo("89.74");
+        assertThat(penaltyAsOf(loan, "2026-08-26")).isEqualByComparingTo("76.92");
+        assertThat(penaltyAsOf(loan, "2026-08-25")).isEqualByComparingTo("64.10");
+        assertThat(penaltyAsOf(loan, "2026-08-24")).isEqualByComparingTo("51.28");
+        // Settling on the installment due date itself is on-time: no LPI at all.
+        assertThat(penaltyAsOf(loan, "2026-08-20")).isEqualByComparingTo("0");
+    }
+
+    @Test
+    @DisplayName("Waived/zero-outstanding charges never contribute")
+    void ignoresNonPenaltyCharges() {
+        final LoanCharge fee = mock(LoanCharge.class);
+        when(fee.isPenaltyCharge()).thenReturn(false);
+        final Loan loan = mock(Loan.class);
+        when(loan.getActiveCharges()).thenReturn(new LinkedHashSet<>(List.of(fee)));
+        assertThat(penaltyAsOf(loan, "2026-08-26")).isEqualByComparingTo("0");
+    }
+}

--- a/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculatorTest.java
+++ b/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculatorTest.java
@@ -67,7 +67,10 @@ class ForeclosurePenaltyCalculatorTest {
         return Money.of(currency, new BigDecimal(amount));
     }
 
-    /** A daily overdue-installment (LPI) charge accrued on {@code accrualDate}, linked to an installment due on {@code owningDueDate}. */
+    /**
+     * A daily overdue-installment (LPI) charge accrued on {@code accrualDate}, linked to an installment due on
+     * {@code owningDueDate}.
+     */
     private LoanCharge linkedLpiCharge(final String accrualDate, final String owningDueDate, final String outstanding) {
         final Money outstandingMoney = money(outstanding);
         final LocalDate accrual = LocalDate.parse(accrualDate);
@@ -140,7 +143,9 @@ class ForeclosurePenaltyCalculatorTest {
                         ForeclosurePenaltyCalculator.computePenaltyQuotedForSettlementDate(loan, LocalDate.parse("2026-08-25"), currency));
     }
 
-    /** Loan 16185: daily 82.19 charges dated 19..27 Aug; ledger shows 739.71 but settlement on 27 Aug collects 657.52. */
+    /**
+     * Loan 16185: daily 82.19 charges dated 19..27 Aug; ledger shows 739.71 but settlement on 27 Aug collects 657.52.
+     */
     private Loan loan16185() {
         final Loan loan = mock(Loan.class);
         final LinkedHashSet<LoanCharge> charges = new LinkedHashSet<>();

--- a/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculatorTest.java
+++ b/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/util/ForeclosurePenaltyCalculatorTest.java
@@ -97,7 +97,7 @@ class ForeclosurePenaltyCalculatorTest {
     }
 
     private BigDecimal penaltyAsOf(final Loan loan, final String settlementDate) {
-        return ForeclosurePenaltyCalculator.computePenaltyPayableFromActiveCharges(loan, LocalDate.parse(settlementDate), currency)
+        return ForeclosurePenaltyCalculator.computePenaltyQuotedForSettlementDate(loan, LocalDate.parse(settlementDate), currency)
                 .getAmount();
     }
 
@@ -132,7 +132,32 @@ class ForeclosurePenaltyCalculatorTest {
     }
 
     @Test
-    @DisplayName("Waived/zero-outstanding charges never contribute")
+    @DisplayName("computePenaltyPayableFromActiveCharges delegates to the quoted settlement-date calculator")
+    void legacyEntryPointMatchesQuotedCalculator() {
+        final Loan loan = loan16184();
+        assertThat(ForeclosurePenaltyCalculator.computePenaltyPayableFromActiveCharges(loan, LocalDate.parse("2026-08-25"), currency))
+                .isEqualByComparingTo(
+                        ForeclosurePenaltyCalculator.computePenaltyQuotedForSettlementDate(loan, LocalDate.parse("2026-08-25"), currency));
+    }
+
+    /** Loan 16185: daily 82.19 charges dated 19..27 Aug; ledger shows 739.71 but settlement on 27 Aug collects 657.52. */
+    private Loan loan16185() {
+        final Loan loan = mock(Loan.class);
+        final LinkedHashSet<LoanCharge> charges = new LinkedHashSet<>();
+        for (LocalDate d = LocalDate.parse("2026-08-19"); !d.isAfter(LocalDate.parse("2026-08-27")); d = d.plusDays(1)) {
+            charges.add(linkedLpiCharge(d.toString(), "2026-08-19", "82.19"));
+        }
+        when(loan.getActiveCharges()).thenReturn(charges);
+        return loan;
+    }
+
+    @Test
+    @DisplayName("Loan 16185: settlement on 27 Aug excludes same-day LPI (657.52 collectable vs 739.71 on ledger)")
+    void loan16185SettlementExcludesSameDayLpi() {
+        assertThat(penaltyAsOf(loan16185(), "2026-08-27")).isEqualByComparingTo("657.52"); // 19..26 Aug
+    }
+
+    @Test
     void ignoresNonPenaltyCharges() {
         final LoanCharge fee = mock(LoanCharge.class);
         when(fee.isPenaltyCharge()).thenReturn(false);

--- a/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/util/LocDueDateRepaymentUtilsTest.java
+++ b/custom/crediblex/portfolio/loanaccount/src/test/java/com/crediblex/fineract/portfolio/loanaccount/util/LocDueDateRepaymentUtilsTest.java
@@ -99,15 +99,15 @@ class LocDueDateRepaymentUtilsTest {
     }
 
     @Test
-    void overdueChargeWaiverFromDateIsInclusiveOnInstallmentDueDate() {
-        final LoanRepaymentScheduleInstallment i1 = installment(LocalDate.of(2026, 8, 3));
+    void overdueChargeWaiverFromDateStartsOnTheSettlementDate() {
         final Loan loan = mock(Loan.class);
-        when(loan.getRepaymentScheduleInstallments()).thenReturn(List.of(i1));
 
+        // The waiver window starts on the settlement date itself for every value date: the client is not charged the
+        // late fee accrued ON the day they settle (nor any later day), whether or not it is an installment due date.
         assertThat(LocDueDateRepaymentUtils.overdueChargeWaiverFromDate(loan, LocalDate.of(2026, 8, 3)))
                 .isEqualTo(LocalDate.of(2026, 8, 3));
         assertThat(LocDueDateRepaymentUtils.overdueChargeWaiverFromDate(loan, LocalDate.of(2026, 8, 4)))
-                .isEqualTo(LocalDate.of(2026, 8, 5));
+                .isEqualTo(LocalDate.of(2026, 8, 4));
         assertThat(LocDueDateRepaymentUtils.overdueChargeWaiverFromDate(loan, null)).isNull();
     }
 


### PR DESCRIPTION

- Refactor penalty calculation logic in CredXLoanReadPlatformServiceImpl to use ForeclosurePenaltyCalculator for accurate penalty amounts.
- Adjust LocDueDateRepaymentUtils to ensure the waiver window starts on the settlement date.
- Add tests to validate the new penalty calculation behavior and ensure correct handling of repayment previews.
- Introduce ForeclosurePenaltyCalculatorTest to cover various scenarios for penalty charges based on settlement dates.

## Description

Describe the changes made and why they were made.

Ignore if these details are present on the associated [Apache Fineract JIRA ticket](https://github.com/apache/fineract/pull/1284).


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
